### PR TITLE
Guest cart checkout

### DIFF
--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -21,3 +21,9 @@
 
   Total Before Tax: $<%= @cart.total_price %>
 <% end %></div>
+
+<% if current_user %>
+  <%= button_to "Checkout" %>
+<% else %>
+  <%= link_to "Login or Create Account to Checkout",  login_path %>
+<% end %>

--- a/spec/features/cart/visitor_checks_out_spec.rb
+++ b/spec/features/cart/visitor_checks_out_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe "a visitor visits their cart" do
+  it "they do not see an option to checkout" do
+    
+
+  end
+
+  it "they see an option to checkout after signing up" do
+
+  end
+
+  it "they see all of the data that was there before logging in" do
+
+  end
+end

--- a/spec/features/cart/visitor_checks_out_spec.rb
+++ b/spec/features/cart/visitor_checks_out_spec.rb
@@ -1,16 +1,35 @@
 require 'rails_helper'
 
 describe "a visitor visits their cart" do
-  it "they do not see an option to checkout" do
-    
-
+  before do
+    item = create(:item)
+    visit items_path
+    first("input.add-to-cart").click
+    find("#go-to-cart").click
   end
 
-  it "they see an option to checkout after signing up" do
+    it "they do not see an option to checkout" do
+      expect(current_path).to eq(cart_path)
+      expect(page).to have_content(Item.first.title)
+      expect(page).to have_content(Item.first.price)
+      expect(page).to have_content(Item.first.description)
+      expect(first("img")['alt']).to have_content(Item.first.title)
+      expect(page).to have_content("Login or Create Account to Checkout")
+    end
 
-  end
+    it "they see an option to checkout after signing up" do
+      click_on("Login or Create Account to Checkout")
 
-  it "they see all of the data that was there before logging in" do
+      expect(current_path).to eq(login_path)
 
-  end
+      user = create(:user)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+      visit cart_path
+
+      expect(page).to have_content("Checkout")
+    end
+
+    xit "they see all of the data that was there before logging in" do
+
+    end
 end

--- a/spec/features/cart/visitor_checks_out_spec.rb
+++ b/spec/features/cart/visitor_checks_out_spec.rb
@@ -29,7 +29,14 @@ describe "a visitor visits their cart" do
       expect(page).to have_content("Checkout")
     end
 
-    xit "they see all of the data that was there before logging in" do
+    it "they see all of the data that was there before logging in" do
+      user = create(:user)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+      visit cart_path
 
+      expect(page).to have_content(Item.first.title)
+      expect(page).to have_content(Item.first.price)
+      expect(page).to have_content(Item.first.description)
+      expect(first("img")['alt']).to have_content(Item.first.title)
     end
 end


### PR DESCRIPTION
Closes #11, Closes #151, Closes #152

Description of Changes: Added to cart show page--if user is a visitor, a link to log in or sign up appears instead of checkout. If user is logged in, button to checkout appears.  Cart data persists from visitor to user being logged in. 

@anlewi5, @josimccllelan, @aziobrow