### PR TITLE
tested that authenticated users can't visit admin pages

### DIFF
--- a/spec/features/security/authenticated_user_security_spec.rb
+++ b/spec/features/security/authenticated_user_security_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe "as an authenticated user" do
+  before do
+    user = create(:user)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+  end
+
+  xit "they cannot view another user's order show page" do
+
+
+  end
+
+  it "they cannot visit an admin order show page" do
+    order = create(:order)
+
+    expect{ visit admin_order_path(order) }.to raise_error(ActionController::RoutingError)
+  end
+
+  it "they cannot visit an admin dashboard" do
+    expect{ visit admin_dashboard_path }.to raise_error(ActionController::RoutingError)
+  end
+end


### PR DESCRIPTION
Closes #22 

Description of Changes:
Just added feature tests to make sure that user can't visit the existing admin pages. 
Xit test for other users order paths for now, because order path is currently in progress but not in staging. 
Added waffle to revisit this test at the end to make sure that we cover any new paths that might be created that we want to test for security. 





@anlewi5, @josimccllelan, @aziobrow


