### PR TITLE
Admin item creation

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -4,29 +4,33 @@ class Admin::ItemsController < ApplicationController
 
   def new
     @item = Item.new
+    @categories = Category.all
   end
 
   def create
     item = Item.new(item_params)
     if item.save
+      item.price = (item.price.to_f * 100).to_i
       flash[:success] = "#{item.title} successfully created"
       redirect_to item_path(item)
     else
       flash[:danger] = item.errors.full_messages.join("\n")
-      redirect_to new_admin_item_page
+      redirect_to new_admin_item_path
     end
   end
 
 private
 
   def item_params
-    params.require(:item).permit(
+    raw_params = params.require(:item).permit(
       :title,
       :description,
       :price,
       :category_id,
       :image_url
     )
+    raw_params[:price] = (raw_params[:price].to_f * 100).to_i
+    raw_params
   end
 
 end

--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -1,0 +1,32 @@
+class Admin::ItemsController < ApplicationController
+
+  before_action :require_admin
+
+  def new
+    @item = Item.new
+  end
+
+  def create
+    item = Item.new(item_params)
+    if item.save
+      flash[:success] = "#{item.title} successfully created"
+      redirect_to item_path(item)
+    else
+      flash[:danger] = item.errors.full_messages.join("\n")
+      redirect_to new_admin_item_page
+    end
+  end
+
+private
+
+  def item_params
+    params.require(:item).permit(
+      :title,
+      :description,
+      :price,
+      :category_id,
+      :image_url
+    )
+  end
+
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -7,7 +7,7 @@ class Category < ApplicationRecord
   before_save :generate_slug
 
   def generate_slug
-    self.slug = name.parameterize
+    self.slug ||= name.parameterize
   end
 
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,6 @@
 class Item < ApplicationRecord
 
-  validates_presence_of :price, :description, :image_url
+  validates_presence_of :price, :description
   validates :title, presence: true, uniqueness: true
 
   belongs_to :category

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,7 @@
 class Item < ApplicationRecord
 
-  validates_presence_of :title, :price, :description, :image_url
+  validates_presence_of :price, :description, :image_url
+  validates :title, presence: true, uniqueness: true
 
   belongs_to :category
   has_many :order_items

--- a/app/views/admin/items/new.html.erb
+++ b/app/views/admin/items/new.html.erb
@@ -1,0 +1,26 @@
+<h2>New Item</h2>
+
+<%= form_for [:admin, @item] do |f| %>
+
+  <%= f.label :title %>
+  <%= f.text_field :title %>
+
+  <%= f.label :description %>
+  <%= f.text_area :description %>
+
+  <%= f.label :price %>
+  <%= f.number_field :price, step: '0.01', min:'0.01' %>
+
+  <%= f.label :image_url %>
+  <%= f.url_field :image_url %>
+
+  <%= f.label :category_id, 'Category' %>
+  <%= f.collection_select :category_id,
+    @categories,
+    :id, :name,
+    prompt: true
+  %>
+
+  <%= f.submit %>
+
+<% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,6 +1,7 @@
 <h2><%= @item.title %></h2>
 <% if @item.retired? %><em>RETIRED</em><% end %>
 <%= image_tag(@item.image_url, size: "100", alt: @item.title) %>
-<p>Price: $<%= @item.price %></p>
+<p>Price: <%= in_dollars(@item.price) %></p>
 <p>Description: <%= @item.description %></p>
+<p>Category: <%= @item.category.name %></p>
 <%= button_to "Add to Cart", cart_path(item_id: @item.id), class: 'add-to-cart' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,19 +8,19 @@ Rails.application.routes.draw do
     post '/login' => :create
     delete '/logout' => :destroy
   end
-
   resources :users, only: [:new, :create]
   get '/dashboard', to: 'users#show'
 
   resources :items, only: [:index, :show]
+  resources :orders, only: [:index, :show]
 
   resource :cart, only: [:create, :show, :destroy, :update]
 
   namespace :admin do
     resources :orders, only: [:show]
+    resources :items, only: [:new, :create]
     get '/dashboard', to: 'users#show'
   end
-  resources :orders, only: [:show, :index]
 
   get '/:slug', to: 'categories#show', as: 'category_items'
 

--- a/db/migrate/20171106023622_update_item_constraints.rb
+++ b/db/migrate/20171106023622_update_item_constraints.rb
@@ -1,0 +1,6 @@
+class UpdateItemConstraints < ActiveRecord::Migration[5.1]
+  def change
+    add_index :items, :title, unique: true
+    change_column :items, :image_url, :string, :null => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171104223159) do
+ActiveRecord::Schema.define(version: 20171106023622) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,12 +23,13 @@ ActiveRecord::Schema.define(version: 20171104223159) do
 
   create_table "items", force: :cascade do |t|
     t.string "title", null: false
-    t.string "image_url", null: false
+    t.string "image_url"
     t.integer "price", null: false
     t.text "description", null: false
     t.bigint "category_id"
     t.boolean "active", default: true, null: false
     t.index ["category_id"], name: "index_items_on_category_id"
+    t.index ["title"], name: "index_items_on_title", unique: true
   end
 
   create_table "order_items", force: :cascade do |t|

--- a/spec/features/admin/items/admin_can_create_an_item_spec.rb
+++ b/spec/features/admin/items/admin_can_create_an_item_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+feature 'When an admin creates an item' do
+
+  background do
+    allow_any_instance_of(ApplicationController)
+      .to receive(:current_user)
+      .and_return(create(:admin))
+    create(:category, name: 'Things')
+
+    visit new_admin_item_path
+    fill_in 'item[title]', with: 'something unique'
+    fill_in 'item[description]', with: 'something descriptive'
+    fill_in 'item[price]', with: '9.99'
+    select 'Things', from: 'item[category_id]'
+  end
+
+  scenario 'they are taken to the item page' do
+    expect(page).to have_current_path(item_path(Item.last))
+  end
+
+  scenario 'they see the details they just entered' do
+    expect(page).to have_content('something unique')
+               .and have_content('something descriptive')
+               .and have_content('$9.99')
+               .and have_content('Things')
+  end
+
+  context 'with the optional image url' do
+    scenario 'they see the image show up on the page' do
+      fill_in 'item[image_url]', with: 'http://backend.turing.io/assets/images/full-logo.png'
+      click_on 'Create Item'
+      expect(page).to have_css('img[src$="full-logo.png"]')
+    end
+  end
+
+end

--- a/spec/features/admin/items/admin_can_create_an_item_spec.rb
+++ b/spec/features/admin/items/admin_can_create_an_item_spec.rb
@@ -16,10 +16,12 @@ feature 'When an admin creates an item' do
   end
 
   scenario 'they are taken to the item page' do
+    click_on 'Create Item'
     expect(page).to have_current_path(item_path(Item.last))
   end
 
   scenario 'they see the details they just entered' do
+    click_on 'Create Item'
     expect(page).to have_content('something unique')
                .and have_content('something descriptive')
                .and have_content('$9.99')

--- a/spec/features/items/visitor_can_see_a_single_item_spec.rb
+++ b/spec/features/items/visitor_can_see_a_single_item_spec.rb
@@ -11,19 +11,19 @@ feature "when a visitor goes to the item show page"do
   end
 
   scenario "they see an image of the item" do
-    expect(first("img")['alt']).to have_content "#{item.title}"
+    expect(first("img")['alt']).to have_content(item.title)
   end
 
   scenario "they see the item title" do
-    expect(page).to have_content("#{item.title}")
+    expect(page).to have_content(item.title)
   end
 
   scenario "they see the price of the item" do
-    expect(page).to have_content("$#{item.price}")
+    expect(page).to have_content('$%.2f' % (item.price / 100.0))
   end
 
   scenario "they see the item's description" do
-    expect(page).to have_content("#{item.description}")
+    expect(page).to have_content(item.description)
   end
 
   scenario "they see a link to add the item to their cart" do

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -4,7 +4,17 @@ describe Item do
 
   describe 'validations' do
 
-    it 'succeed with a unique title, description, price, image url, and category' do
+    it 'succeed with a unique title, description, price, and category' do
+      item = Item.new(
+        title: 'item title',
+        description: 'item description',
+        price: 9.99,
+        category: create(:category)
+      )
+      expect(item).to be_valid
+    end
+
+    it 'succeed with a optional image url' do
       item = Item.new(
         title: 'item title',
         description: 'item description',
@@ -21,7 +31,6 @@ describe Item do
         title: 'item title',
         description: 'item description',
         price: 9.99,
-        image_url: 'example.com/item.jpg',
         category: create(:category)
       )
       expect(item).to_not be_valid
@@ -31,7 +40,6 @@ describe Item do
       item = Item.new(
         description: 'item description',
         price: 9.99,
-        image_url: 'example.com/item.jpg',
         category: create(:category)
       )
       expect(item).to_not be_valid
@@ -41,7 +49,6 @@ describe Item do
       item = Item.new(
         title: 'item name',
         price: 9.99,
-        image_url: 'example.com/item.jpg',
         category: create(:category)
       )
       expect(item).to_not be_valid
@@ -51,17 +58,6 @@ describe Item do
       item = Item.new(
         title: 'item name',
         description: 'item description',
-        image_url: 'example.com/item.jpg',
-        category: create(:category)
-      )
-      expect(item).to_not be_valid
-    end
-
-    it 'fail without an image url' do
-      item = Item.new(
-        title: 'item name',
-        description: 'item description',
-        price: 9.99,
         category: create(:category)
       )
       expect(item).to_not be_valid
@@ -72,7 +68,6 @@ describe Item do
         title: 'item name',
         description: 'item description',
         price: 9.99,
-        image_url: 'example.com/item.jpg'
       )
       expect(item).to_not be_valid
     end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -4,7 +4,7 @@ describe Item do
 
   describe 'validations' do
 
-    it 'succeed with a title, description, price, image url, and category' do
+    it 'succeed with a unique title, description, price, image url, and category' do
       item = Item.new(
         title: 'item title',
         description: 'item description',
@@ -13,6 +13,18 @@ describe Item do
         category: create(:category)
       )
       expect(item).to be_valid
+    end
+
+    it 'fail when the title is already taken' do
+      create(:item, title: 'item title')
+      item = Item.new(
+        title: 'item title',
+        description: 'item description',
+        price: 9.99,
+        image_url: 'example.com/item.jpg',
+        category: create(:category)
+      )
+      expect(item).to_not be_valid
     end
 
     it 'fail without a title' do


### PR DESCRIPTION
closes #10 closes #168, closes #169, closes #170

Description of Changes:
Add specs, routes, actions, and views to let an admin create an item

@anlewi5, @josimccllelan, @aziobrow


