### PR TITLE
Admin order status

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -3,6 +3,7 @@ class Admin::UsersController < ApplicationController
   before_action :require_admin
 
   def show
+    @orders = Order.all
   end
 
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -9,4 +9,9 @@ class OrdersController < ApplicationController
     @orders = current_user.orders
   end
 
+  def update
+    @orders = Order.update(params[:id], status: params[:status])
+    redirect_back(fallback_location: admin_dashboard_path)
+  end
+
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -12,6 +12,10 @@ class Order < ApplicationRecord
     order_items.sum('unit_cost * quantity')
   end
 
+  def self.by_status(status)
+    where(status: status)
+  end
+
 private
 
   def save_purchaser_name

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,1 +1,35 @@
 <h1>Admin Dashboard</h1>
+
+<h3> Ordered (<%= @orders.by_status("ordered").count %>) </h3>
+  <ul>
+    <% @orders.by_status("ordered").each do |ordered_order| %>
+    <li><%= link_to "Order ##{ordered_order.id}", admin_order_path(ordered_order) %>
+      <%= link_to "Cancel",  order_path(id: ordered_order.id, status: "cancelled"), method: :patch %>
+      <%= link_to "Mark as Paid", order_path(id: ordered_order.id, status: "paid"), method: :patch %>
+    </li>
+    <% end %>
+  </ul>
+
+<h3> Paid (<%= @orders.by_status("paid").count %>) </h3>
+  <ul>
+    <% @orders.by_status("paid").each do |paid_order| %>
+    <li><%= link_to "Order ##{paid_order.id}", admin_order_path(paid_order) %>
+      <%= link_to "Cancel", order_path(id: paid_order.id, status: "cancelled"), method: :patch %>
+      <%= link_to "Mark as Completed", order_path(id: paid_order.id, status: "completed"), method: :patch %>
+    </li>
+    <% end %>
+  </ul>
+
+<h3> Cancelled (<%= @orders.by_status("cancelled").count %>) </h3>
+  <ul>
+    <% @orders.by_status("cancelled").each do |cancelled_order| %>
+    <li><%= link_to "Order ##{cancelled_order.id}", admin_order_path(cancelled_order) %></li>
+    <% end %>
+  </ul>
+
+<h3> Completed (<%= @orders.by_status("completed").count %>) </h3>
+  <ul>
+    <% @orders.by_status("completed").each do |completed_order| %>
+    <li><%= link_to "Order ##{completed_order.id}", admin_order_path(completed_order) %></li>
+    <% end %>
+  </ul>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -4,8 +4,8 @@
   <ul>
     <% @orders.by_status("ordered").each do |ordered_order| %>
     <li><%= link_to "Order ##{ordered_order.id}", admin_order_path(ordered_order) %>
-      <%= link_to "Cancel",  order_path(id: ordered_order.id, status: "cancelled"), method: :patch %>
-      <%= link_to "Mark as Paid", order_path(id: ordered_order.id, status: "paid"), method: :patch %>
+      <div class='cancel-link'><%= link_to "Cancel",  order_path(id: ordered_order.id, status: "cancelled"), method: :patch %></div>
+      <div class='paid-link'><%= link_to "Mark as Paid", order_path(id: ordered_order.id, status: "paid"), method: :patch %></div>
     </li>
     <% end %>
   </ul>
@@ -14,8 +14,8 @@
   <ul>
     <% @orders.by_status("paid").each do |paid_order| %>
     <li><%= link_to "Order ##{paid_order.id}", admin_order_path(paid_order) %>
-      <%= link_to "Cancel", order_path(id: paid_order.id, status: "cancelled"), method: :patch %>
-      <%= link_to "Mark as Completed", order_path(id: paid_order.id, status: "completed"), method: :patch %>
+      <div class='cancel-link'><%= link_to "Cancel", order_path(id: paid_order.id, status: "cancelled"), method: :patch %></div>
+      <div class='completed-link'><%= link_to "Mark as Completed", order_path(id: paid_order.id, status: "completed"), method: :patch %></div>
     </li>
     <% end %>
   </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
   get '/dashboard', to: 'users#show'
 
   resources :items, only: [:index, :show]
-  resources :orders, only: [:index, :show]
+  resources :orders, only: [:index, :show, :update]
 
   resource :cart, only: [:create, :show, :destroy, :update]
 

--- a/spec/features/admin/orders/admin_can_view_orders_by_status_in_dashboard_spec.rb
+++ b/spec/features/admin/orders/admin_can_view_orders_by_status_in_dashboard_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+describe "when an admin visits admin dashboard" do
+  before do
+    admin = create(:user, username: 'JaneAdmin89', password: 'pw', email: 'janeadmin89@example.com', role: 'admin')
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+    @order1 = create(:order, status: "ordered")
+    @order2 = create(:order, status: "ordered")
+    @order3 = create(:order, status: "paid")
+    @order4 = create(:order, status: "cancelled")
+    @order5 = create(:order, status: "completed")
+    visit admin_dashboard_path
+    save_and_open_page
+  end
+
+  it "they see a listing of all orders" do
+    expect(page).to have_content("Order ##{@order1.id}")
+    expect(page).to have_content("Order ##{@order2.id}")
+    expect(page).to have_content("Order ##{@order3.id}")
+    expect(page).to have_content("Order ##{@order4.id}")
+    expect(page).to have_content("Order ##{@order5.id}")
+  end
+
+  it "they see the total number of orders for each status" do
+    expect(page).to have_content("Ordered (2)")
+    expect(page).to have_content("Paid (1)")
+    expect(page).to have_content("Cancelled (1)")
+    expect(page).to have_content("Completed (1)")
+  end
+
+  it "they see a link for each individual order" do
+    expect(page).to have_link("Order ##{@order1.id}", href: admin_order_path(@order1))
+    expect(page).to have_link("Order ##{@order2.id}", href: admin_order_path(@order2))
+    expect(page).to have_link("Order ##{@order3.id}", href: admin_order_path(@order3))
+    expect(page).to have_link("Order ##{@order4.id}", href: admin_order_path(@order4))
+    expect(page).to have_link("Order ##{@order5.id}", href: admin_order_path(@order5))
+  end
+
+  xit "they can filter orders to display by status type" do
+
+  end
+
+  it "they can click a link to cancel paid orders" do
+    click_on "Cancel"
+
+    expect(page).to have_content("Paid (0)")
+    expect(page).to have_content("Cancelled (2)")
+  end
+
+  it "they can click a link to cancel ordered orders" do
+    click_on "Cancel"
+
+    expect(page).to have_content("Ordered (1)")
+    expect(page).to have_content("Cancelled (2)")
+  end
+
+  it "they can click on a link to mark paid an ordered order" do
+    click_on "Mark as Paid"
+
+    expect(page).to have_content("Ordered (1)")
+    expect(page).to have_content("Paid (2)")
+  end
+
+  it "they can click on a link to complete a paid order" do
+    click_on "Mark as Completed"
+
+    expect(page).to have_content("Paid (0)")
+    expect(page).to have_content("Completed (2)")
+  end
+end

--- a/spec/features/admin/orders/admin_can_view_orders_by_status_in_dashboard_spec.rb
+++ b/spec/features/admin/orders/admin_can_view_orders_by_status_in_dashboard_spec.rb
@@ -10,7 +10,6 @@ describe "when an admin visits admin dashboard" do
     @order4 = create(:order, status: "cancelled")
     @order5 = create(:order, status: "completed")
     visit admin_dashboard_path
-    save_and_open_page
   end
 
   it "they see a listing of all orders" do
@@ -41,21 +40,21 @@ describe "when an admin visits admin dashboard" do
   end
 
   it "they can click a link to cancel paid orders" do
-    click_on "Cancel"
+    page.all('.cancel-link a')[2].click
 
     expect(page).to have_content("Paid (0)")
     expect(page).to have_content("Cancelled (2)")
   end
 
   it "they can click a link to cancel ordered orders" do
-    click_on "Cancel"
+    first('.cancel-link').click_link('Cancel')
 
     expect(page).to have_content("Ordered (1)")
     expect(page).to have_content("Cancelled (2)")
   end
 
   it "they can click on a link to mark paid an ordered order" do
-    click_on "Mark as Paid"
+    first('.paid-link').click_link('Mark as Paid')
 
     expect(page).to have_content("Ordered (1)")
     expect(page).to have_content("Paid (2)")

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -12,7 +12,7 @@ describe Order do
     it 'fail without a user' do
       expect(Order.new).to_not be_valid
     end
-        
+
     it 'pass with optional service address' do
       order = Order.new(user: create(:user), service_address: '1234 Fake St.')
       expect(order).to be_valid
@@ -52,6 +52,25 @@ describe Order do
     it '#total_cost returns the total cost in cents' do
       order = create(:order_item, unit_cost: 199, quantity: 2).order
       expect(order.total_cost).to eq(398)
+    end
+  end
+
+  describe 'class methods' do
+    it 'by status returns all orders of a given status' do
+      order1 = create(:order, status: "paid")
+      order2 = create(:order, status: "cancelled")
+      order3 = create(:order, status: "ordered")
+      order4 = create(:order, status: "completed")
+
+      expect(Order.all.count).to eq(4)
+      expect(Order.by_status("paid").count).to eq(1)
+      expect(Order.by_status("paid").first.status).to eq("paid")
+      expect(Order.by_status("cancelled").count).to eq(1)
+      expect(Order.by_status("cancelled").first.status).to eq("cancelled")
+      expect(Order.by_status("ordered").count).to eq(1)
+      expect(Order.by_status("ordered").first.status).to eq("ordered")
+      expect(Order.by_status("completed").count).to eq(1)
+      expect(Order.by_status("completed").first.status).to eq("completed")
     end
   end
 


### PR DESCRIPTION
Closes #176, Closes #15, Closes #181, Closes #180, Closes #173, Closes #178, Closes #175, Closes #177, Closes #174 

Description of Changes:
Admin Dashboard is now a sectioned list of all orders, grouped by status. You can click a link to cancel a paid or ordered order, or to mark an ordered order as paid, or a paid order as completed. You can see how many orders fall into each status category. Order model updated with a method to group by status. Feature and model tests passing. 






@anlewi5, @josimccllelan, @aziobrow


