### PR TITLE
Update admin dashboard

### DIFF
--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -7,19 +7,8 @@ class Admin::OrdersController < ApplicationController
   end
 
   def index
-    if params[:status] == "ordered"
-      @orders = Order.by_status("ordered")
-      @status = "ordered"
-    elsif params[:status] == "paid"
-      @orders = Order.by_status("paid")
-      @status = "paid"
-    elsif params[:status] == "cancelled"
-      @orders = Order.by_status("cancelled")
-      @status = "cancelled"
-    else
-      @orders = Order.by_status("completed")
-      @status = "completed"
-    end
+    @status = params[:status]
+    @orders = Order.by_status(@status)
   end
 
 end

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -6,4 +6,16 @@ class Admin::OrdersController < ApplicationController
     @order = Order.find(params[:id])
   end
 
+  def index
+    if params[:status] == "ordered"
+      @orders = Order.by_status("ordered")
+    elsif params[:status] == "paid"
+      @orders = Order.by_status("paid")
+    elsif params[:status] == "cancelled"
+      @orders = Order.by_status("cancelled")
+    else
+      @orders = Order.by_status("completed")
+    end
+  end
+
 end

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -9,12 +9,16 @@ class Admin::OrdersController < ApplicationController
   def index
     if params[:status] == "ordered"
       @orders = Order.by_status("ordered")
+      @status = "ordered"
     elsif params[:status] == "paid"
       @orders = Order.by_status("paid")
+      @status = "paid"
     elsif params[:status] == "cancelled"
       @orders = Order.by_status("cancelled")
+      @status = "cancelled"
     else
       @orders = Order.by_status("completed")
+      @status = "completed"
     end
   end
 

--- a/app/views/admin/orders/index.html.erb
+++ b/app/views/admin/orders/index.html.erb
@@ -1,0 +1,12 @@
+<h2> <%= @orders.first.status.capitalize %> Orders </h2>
+<% @orders.each do |order| %>
+  <li><%= link_to "Order ##{order.id}", admin_order_path(order) %></li>
+  <% if order.status == "ordered" %>
+    <div class='cancel-link'><%= link_to "Cancel",  order_path(id: ordered_order.id, status: "cancelled"), method: :patch %></div>
+    <div class='paid-link'><%= link_to "Mark as Paid", order_path(id: ordered_order.id, status: "paid"), method: :patch %></div>
+  <% elsif order.status == "paid" %>
+    <div class='cancel-link'><%= link_to "Cancel", order_path(id: paid_order.id, status: "cancelled"), method: :patch %></div>
+    <div class='completed-link'><%= link_to "Mark as Completed", order_path(id: paid_order.id, status: "completed"), method: :patch %></div>
+  <% else %>
+  <% end %>    
+<% end %>

--- a/app/views/admin/orders/index.html.erb
+++ b/app/views/admin/orders/index.html.erb
@@ -1,12 +1,14 @@
-<h2> <%= @orders.first.status.capitalize %> Orders </h2>
+<h2> <%= @status.capitalize %> Orders </h2>
 <% @orders.each do |order| %>
   <li><%= link_to "Order ##{order.id}", admin_order_path(order) %></li>
-  <% if order.status == "ordered" %>
-    <div class='cancel-link'><%= link_to "Cancel",  order_path(id: ordered_order.id, status: "cancelled"), method: :patch %></div>
-    <div class='paid-link'><%= link_to "Mark as Paid", order_path(id: ordered_order.id, status: "paid"), method: :patch %></div>
-  <% elsif order.status == "paid" %>
-    <div class='cancel-link'><%= link_to "Cancel", order_path(id: paid_order.id, status: "cancelled"), method: :patch %></div>
-    <div class='completed-link'><%= link_to "Mark as Completed", order_path(id: paid_order.id, status: "completed"), method: :patch %></div>
+  <% if @status == "ordered" %>
+    <div class='cancel-link'><%= link_to "Cancel",  order_path(id: order.id, status: "cancelled"), method: :patch %></div>
+    <div class='paid-link'><%= link_to "Mark as Paid", order_path(id: order.id, status: "paid"), method: :patch %></div>
+  <% elsif @status == "paid" %>
+    <div class='cancel-link'><%= link_to "Cancel", order_path(id: order.id, status: "cancelled"), method: :patch %></div>
+    <div class='completed-link'><%= link_to "Mark as Completed", order_path(id: order.id, status: "completed"), method: :patch %></div>
   <% else %>
-  <% end %>    
+  <% end %>
 <% end %>
+
+<%= link_to "Back to All Orders", admin_dashboard_path %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,35 +1,13 @@
 <h1>Admin Dashboard</h1>
 
-<h3> Ordered (<%= @orders.by_status("ordered").count %>) </h3>
+<h3> All Orders </h3>
   <ul>
-    <% @orders.by_status("ordered").each do |ordered_order| %>
-    <li><%= link_to "Order ##{ordered_order.id}", admin_order_path(ordered_order) %>
-      <div class='cancel-link'><%= link_to "Cancel",  order_path(id: ordered_order.id, status: "cancelled"), method: :patch %></div>
-      <div class='paid-link'><%= link_to "Mark as Paid", order_path(id: ordered_order.id, status: "paid"), method: :patch %></div>
-    </li>
-    <% end %>
-  </ul>
+    <% @orders.each do |order| %>
+      <li><%= link_to "Order ##{order.id}", admin_order_path(order) %></li>
+  <% end %>
 
-<h3> Paid (<%= @orders.by_status("paid").count %>) </h3>
-  <ul>
-    <% @orders.by_status("paid").each do |paid_order| %>
-    <li><%= link_to "Order ##{paid_order.id}", admin_order_path(paid_order) %>
-      <div class='cancel-link'><%= link_to "Cancel", order_path(id: paid_order.id, status: "cancelled"), method: :patch %></div>
-      <div class='completed-link'><%= link_to "Mark as Completed", order_path(id: paid_order.id, status: "completed"), method: :patch %></div>
-    </li>
-    <% end %>
-  </ul>
 
-<h3> Cancelled (<%= @orders.by_status("cancelled").count %>) </h3>
-  <ul>
-    <% @orders.by_status("cancelled").each do |cancelled_order| %>
-    <li><%= link_to "Order ##{cancelled_order.id}", admin_order_path(cancelled_order) %></li>
-    <% end %>
-  </ul>
-
-<h3> Completed (<%= @orders.by_status("completed").count %>) </h3>
-  <ul>
-    <% @orders.by_status("completed").each do |completed_order| %>
-    <li><%= link_to "Order ##{completed_order.id}", admin_order_path(completed_order) %></li>
-    <% end %>
-  </ul>
+  <h2> <%= link_to "Ordered (#{@orders.by_status("ordered").count})", admin_orders_path(status: "ordered") %></h2>
+  <h2> <%= link_to "Paid (#{@orders.by_status("paid").count})", admin_orders_path(status: "paid") %> </h2>
+  <h2> <%= link_to "Cancelled (#{@orders.by_status("cancelled").count})", admin_orders_path(status: "cancelled") %> </h2>
+  <h2> <%= link_to "Completed (#{@orders.by_status("completed").count})", admin_orders_path(status: "completed") %> </h2>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -7,7 +7,7 @@
   <% end %>
 
 
-  <h2> <%= link_to "Ordered (#{@orders.by_status("ordered").count})", admin_orders_path(status: "ordered") %></h2>
-  <h2> <%= link_to "Paid (#{@orders.by_status("paid").count})", admin_orders_path(status: "paid") %> </h2>
-  <h2> <%= link_to "Cancelled (#{@orders.by_status("cancelled").count})", admin_orders_path(status: "cancelled") %> </h2>
-  <h2> <%= link_to "Completed (#{@orders.by_status("completed").count})", admin_orders_path(status: "completed") %> </h2>
+  <h2> <%= link_to "Ordered (#{@orders.ordered.count})", admin_orders_path(status: "ordered") %></h2>
+  <h2> <%= link_to "Paid (#{@orders.paid.count})", admin_orders_path(status: "paid") %> </h2>
+  <h2> <%= link_to "Cancelled (#{@orders.cancelled.count})", admin_orders_path(status: "cancelled") %> </h2>
+  <h2> <%= link_to "Completed (#{@orders.completed.count})", admin_orders_path(status: "completed") %> </h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
   resource :cart, only: [:create, :show, :destroy, :update]
 
   namespace :admin do
-    resources :orders, only: [:show]
+    resources :orders, only: [:show, :index]
     resources :items, only: [:new, :create]
     get '/dashboard', to: 'users#show'
   end

--- a/spec/features/admin/orders/admin_can_view_orders_by_status_in_dashboard_spec.rb
+++ b/spec/features/admin/orders/admin_can_view_orders_by_status_in_dashboard_spec.rb
@@ -35,7 +35,8 @@ describe "when an admin visits admin dashboard" do
     expect(page).to have_link("Order ##{@order5.id}", href: admin_order_path(@order5))
   end
 
-  xit "they can filter orders to display by status type" do
+  it "they can filter orders to display by status type" do
+    
 
   end
 

--- a/spec/features/admin/orders/admin_can_view_orders_by_status_in_dashboard_spec.rb
+++ b/spec/features/admin/orders/admin_can_view_orders_by_status_in_dashboard_spec.rb
@@ -36,33 +36,71 @@ describe "when an admin visits admin dashboard" do
   end
 
   it "they can filter orders to display by status type" do
-    
+    click_link("Ordered (2)")
 
+    expect(current_path).to eq(admin_orders_path)
+    expect(page).to have_link("Order ##{@order1.id}", href: admin_order_path(@order1))
+    expect(page).to have_link("Order ##{@order2.id}", href: admin_order_path(@order2))
+    expect(page).to_not have_link("Order ##{@order3.id}", href: admin_order_path(@order3))
+    expect(page).to_not have_link("Order ##{@order4.id}", href: admin_order_path(@order4))
+    expect(page).to_not have_link("Order ##{@order5.id}", href: admin_order_path(@order5))
   end
 
   it "they can click a link to cancel paid orders" do
-    page.all('.cancel-link a')[2].click
+    click_link("Paid (1)")
 
-    expect(page).to have_content("Paid (0)")
+    expect(page).to have_link("Order ##{@order3.id}", href: admin_order_path(@order3))
+
+    click_link("Cancel")
+    expect(page).to_not have_link("Order ##{@order3.id}", href: admin_order_path(@order3))
+
+    visit admin_dashboard_path
+
     expect(page).to have_content("Cancelled (2)")
+    expect(page).to have_content("Paid (0)")
   end
 
   it "they can click a link to cancel ordered orders" do
+    click_link("Ordered (2)")
+
+    expect(page).to have_link("Order ##{@order1.id}", href: admin_order_path(@order1))
+    expect(page).to have_link("Order ##{@order2.id}", href: admin_order_path(@order2))
+
     first('.cancel-link').click_link('Cancel')
+    expect(page).to_not have_link("Order ##{@order1.id}", href: admin_order_path(@order1))
+    expect(page).to have_link("Order ##{@order2.id}", href: admin_order_path(@order2))
+
+    visit admin_dashboard_path
 
     expect(page).to have_content("Ordered (1)")
     expect(page).to have_content("Cancelled (2)")
   end
 
   it "they can click on a link to mark paid an ordered order" do
+    click_link("Ordered (2)")
+
+    expect(page).to have_link("Order ##{@order1.id}", href: admin_order_path(@order1))
+    expect(page).to have_link("Order ##{@order2.id}", href: admin_order_path(@order2))
+
     first('.paid-link').click_link('Mark as Paid')
+    expect(page).to_not have_link("Order ##{@order1.id}", href: admin_order_path(@order1))
+    expect(page).to have_link("Order ##{@order2.id}", href: admin_order_path(@order2))
+
+    visit admin_dashboard_path
 
     expect(page).to have_content("Ordered (1)")
     expect(page).to have_content("Paid (2)")
   end
 
   it "they can click on a link to complete a paid order" do
-    click_on "Mark as Completed"
+    click_link("Paid (1)")
+
+    expect(page).to have_link("Order ##{@order3.id}", href: admin_order_path(@order3))
+
+    first('.paid-link').click_link('Mark as Paid')
+    expect(page).to_not have_link("Order ##{@order3.id}", href: admin_order_path(@order3))
+
+    visit admin_dashboard_path
 
     expect(page).to have_content("Paid (0)")
     expect(page).to have_content("Completed (2)")

--- a/spec/features/admin/orders/admin_can_view_orders_by_status_in_dashboard_spec.rb
+++ b/spec/features/admin/orders/admin_can_view_orders_by_status_in_dashboard_spec.rb
@@ -78,6 +78,7 @@ describe "when an admin visits admin dashboard" do
 
   it "they can click on a link to mark paid an ordered order" do
     click_link("Ordered (2)")
+    save_and_open_page
 
     expect(page).to have_link("Order ##{@order1.id}", href: admin_order_path(@order1))
     expect(page).to have_link("Order ##{@order2.id}", href: admin_order_path(@order2))
@@ -97,7 +98,8 @@ describe "when an admin visits admin dashboard" do
 
     expect(page).to have_link("Order ##{@order3.id}", href: admin_order_path(@order3))
 
-    first('.paid-link').click_link('Mark as Paid')
+    click_link('Mark as Completed')
+    
     expect(page).to_not have_link("Order ##{@order3.id}", href: admin_order_path(@order3))
 
     visit admin_dashboard_path

--- a/spec/features/admin/orders/admin_can_view_orders_by_status_in_dashboard_spec.rb
+++ b/spec/features/admin/orders/admin_can_view_orders_by_status_in_dashboard_spec.rb
@@ -78,7 +78,6 @@ describe "when an admin visits admin dashboard" do
 
   it "they can click on a link to mark paid an ordered order" do
     click_link("Ordered (2)")
-    save_and_open_page
 
     expect(page).to have_link("Order ##{@order1.id}", href: admin_order_path(@order1))
     expect(page).to have_link("Order ##{@order2.id}", href: admin_order_path(@order2))
@@ -99,7 +98,7 @@ describe "when an admin visits admin dashboard" do
     expect(page).to have_link("Order ##{@order3.id}", href: admin_order_path(@order3))
 
     click_link('Mark as Completed')
-    
+
     expect(page).to_not have_link("Order ##{@order3.id}", href: admin_order_path(@order3))
 
     visit admin_dashboard_path


### PR DESCRIPTION
Closes #189

Description of Changes:
Admin can now click on links to see orders by status
Created route for admin orders index which is the filtered by status view
Updated feature tests accordingly





@anlewi5, @josimccllelan, @aziobrow


