### PR TITLE
Rename table items

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -45,11 +45,11 @@ private
     raw_params = params.require(:item).permit(
       :title,
       :description,
-      :price,
+      :unit_price,
       :category_id,
       :image_url
     )
-    raw_params[:price] = (raw_params[:price].to_f * 100).round
+    raw_params[:unit_price] = (raw_params[:unit_price].to_f * 100).round
     raw_params
   end
 

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -36,7 +36,7 @@ private
     set_cart.contents.each do |key, value|
       order.order_items.new(
         item_id: key.to_i,
-        unit_cost: Item.find(key.to_i).price,
+        unit_cost: Item.find(key.to_i).unit_price,
         quantity: value
       )
     end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -32,7 +32,7 @@ private
   end
 
   def checkout_items
-    order = current_user.orders.new
+    order = current_user.orders.new(original_address: current_user.address)
     set_cart.contents.each do |key, value|
       order.order_items.new(
         item_id: key.to_i,

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -36,7 +36,7 @@ private
     set_cart.contents.each do |key, value|
       order.order_items.new(
         item_id: key.to_i,
-        unit_cost: Item.find(key.to_i).unit_price,
+        original_unit_price: Item.find(key.to_i).unit_price,
         quantity: value
       )
     end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -28,7 +28,7 @@ class OrdersController < ApplicationController
 private
 
   def order_params
-    params.require(:order).permit(:original_address, :purchaser_name)
+    params.require(:order).permit(:original_address, :original_purchaser)
   end
 
   def checkout_items

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -28,7 +28,7 @@ class OrdersController < ApplicationController
 private
 
   def order_params
-    params.require(:order).permit(:service_address, :purchaser_name)
+    params.require(:order).permit(:original_address, :purchaser_name)
   end
 
   def checkout_items

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -25,7 +25,7 @@ class UsersController < ApplicationController
 private
 
   def user_params
-    params.require(:user).permit(:username, :email, :password, :password_confirmation)
+    params.require(:user).permit(:name, :address, :username, :email, :password, :password_confirmation)
   end
 
 end

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -26,8 +26,8 @@ class Cart
     contents.transform_keys {|key| Item.find(key.to_i)}
   end
 
-  def total_price
-    cart_items.sum  {|item, quantity| item.price * quantity}
+  def total_unit_price
+    cart_items.sum  {|item, quantity| item.unit_price * quantity}
   end
 
   def update_quantity(id, new_quantity)

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -26,7 +26,7 @@ class Cart
     contents.transform_keys {|key| Item.find(key.to_i)}
   end
 
-  def total_unit_price
+  def total_price
     cart_items.sum  {|item, quantity| item.unit_price * quantity}
   end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -7,7 +7,7 @@ class Item < ApplicationRecord
   belongs_to :category
   has_many :order_items
 
-  def subtotal_unit_price(quantity)
+  def subtotal(quantity)
     self.unit_price * quantity
   end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,13 +2,13 @@ class Item < ApplicationRecord
 
   validates_presence_of :description
   validates :title, presence: true, uniqueness: true
-  validates :price, presence: true, :numericality => { :greater_than_or_equal_to => 0 }
+  validates :unit_price, presence: true, :numericality => { :greater_than_or_equal_to => 0 }
 
   belongs_to :category
   has_many :order_items
 
-  def subtotal_price(quantity)
-    self.price * quantity
+  def subtotal_unit_price(quantity)
+    self.unit_price * quantity
   end
 
   def retired?

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -3,9 +3,9 @@ class Order < ApplicationRecord
   belongs_to :user
   has_many :order_items
 
-  validates_presence_of :purchaser_name, :status
+  validates_presence_of :original_purchaser, :status
   validates_associated :order_items
-  before_validation :save_purchaser_name
+  before_validation :save_original_purchaser
 
 
   enum status: ['ordered', 'paid', 'cancelled', 'completed']
@@ -20,8 +20,8 @@ class Order < ApplicationRecord
 
 private
 
-  def save_purchaser_name
-    self.purchaser_name ||= user && user.username
+  def save_original_purchaser
+    self.original_purchaser ||= user && user.username
   end
 
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -11,7 +11,7 @@ class Order < ApplicationRecord
   enum status: ['ordered', 'paid', 'cancelled', 'completed']
 
   def total_cost
-    order_items.sum('unit_cost * quantity')
+    order_items.sum('original_unit_price * quantity')
   end
 
   def self.by_status(status)

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -1,20 +1,20 @@
 class OrderItem < ApplicationRecord
 
-  validates_presence_of :unit_cost
+  validates_presence_of :original_unit_price
   validates :quantity, presence: true, :numericality => { :greater_than_or_equal_to => 0 }
 
   belongs_to :order
   belongs_to :item
-  before_validation :save_unit_cost
+  before_validation :save_original_unit_price
 
   def subtotal
-    unit_cost * quantity
+    original_unit_price * quantity
   end
 
 private
 
-  def save_unit_cost
-    self.unit_cost ||= item && item.unit_price
+  def save_original_unit_price
+    self.original_unit_price ||= item && item.unit_price
   end
 
 end

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -14,7 +14,7 @@ class OrderItem < ApplicationRecord
 private
 
   def save_unit_cost
-    self.unit_cost ||= item && item.price
+    self.unit_cost ||= item && item.unit_price
   end
 
 end

--- a/app/views/admin/items/_form.html.erb
+++ b/app/views/admin/items/_form.html.erb
@@ -6,8 +6,8 @@
   <%= f.label :description %>
   <%= f.text_area :description %>
 
-  <%= f.label :price %>
-  <%= f.number_field :price, step: '0.01', min:'0.01', value: (@item.price || 0) / 100.0 %>
+  <%= f.label :unit_price %>
+  <%= f.number_field :unit_price, step: '0.01', min:'0.01', value: (@item.unit_price || 0) / 100.0 %>
 
   <%= f.label :image_url %>
   <%= f.url_field :image_url %>

--- a/app/views/admin/order_items/_order_item.html.erb
+++ b/app/views/admin/order_items/_order_item.html.erb
@@ -1,6 +1,6 @@
 <li class="order-item listing">
   <p>Item: <%= link_to order_item.item.title, item_path(order_item.item) %></p>
   <p>Quantity: <%= order_item.quantity %></p>
-  <p>Unit Cost: <%= in_dollars(order_item.unit_cost) %></p>
+  <p>Unit Cost: <%= in_dollars(order_item.original_unit_price) %></p>
   <p>Subtotal: <%= in_dollars(order_item.subtotal) %></p>
 </li>

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -1,6 +1,6 @@
 <h2>Order Details</h2>
 
-<p>Purchaser: <%= @order.purchaser_name %></p>
+<p>Purchaser: <%= @order.original_purchaser %></p>
 <% if @order.original_address %>
   <p>Service Adress: <%= @order.original_address %></p>
 <% end %>

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -1,8 +1,8 @@
 <h2>Order Details</h2>
 
 <p>Purchaser: <%= @order.purchaser_name %></p>
-<% if @order.service_address %>
-  <p>Service Adress: <%= @order.service_address %></p>
+<% if @order.original_address %>
+  <p>Service Adress: <%= @order.original_address %></p>
 <% end %>
 <p>Time: <%= @order.created_at %></p>
 <p>Status: <%= @order.status %></p>

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -14,12 +14,12 @@
     <% end %>
     Description: <%= item.description %>
     unit_price: <%= in_dollars(item.unit_price) %>
-    Item Subtotal: <%= in_dollars(item.subtotal_unit_price(quantity)) %>
+    Item Subtotal: <%= in_dollars(item.subtotal(quantity)) %>
     <%= image_tag(item.image_url, size: "100x100", alt: item.title) %>
     <%= link_to "Remove", cart_path(item_id: item.id), method: :delete %>
   <% end %>
 
-  Total Before Tax: $<%= @cart.total_unit_price %>
+  Total Before Tax: $<%= @cart.total %>
 <% end %></div>
 
 <% if logged_in? %>

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -19,7 +19,7 @@
     <%= link_to "Remove", cart_path(item_id: item.id), method: :delete %>
   <% end %>
 
-  Total Before Tax: $<%= @cart.total %>
+  Total Before Tax: $<%= @cart.total_price %>
 <% end %></div>
 
 <% if logged_in? %>

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -13,13 +13,13 @@
       <%= submit_tag("Update Quantity") %>
     <% end %>
     Description: <%= item.description %>
-    Price: <%= in_dollars(item.price) %>
-    Item Subtotal: <%= in_dollars(item.subtotal_price(quantity)) %>
+    unit_price: <%= in_dollars(item.unit_price) %>
+    Item Subtotal: <%= in_dollars(item.subtotal_unit_price(quantity)) %>
     <%= image_tag(item.image_url, size: "100x100", alt: item.title) %>
     <%= link_to "Remove", cart_path(item_id: item.id), method: :delete %>
   <% end %>
 
-  Total Before Tax: $<%= @cart.total_price %>
+  Total Before Tax: $<%= @cart.total_unit_price %>
 <% end %></div>
 
 <% if logged_in? %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,7 +4,7 @@
     <br />
     <h2> <%= @item.title %> </h2>
     <h4> <% if @item.retired? %><em>RETIRED</em><% end %> </h4>
-    <h3>Price: <%= in_dollars(@item.price) %></h3>
+    <h3>unit_price: <%= in_dollars(@item.unit_price) %></h3>
     <h3>Description: <%= @item.description %></h3>
     <h3>Category: <%= @item.category.name %></h3>
     <%= button_to "Add to Cart", cart_path(item_id: @item.id), class: 'btn btn-primary add-to-cart' %>

--- a/app/views/order_items/_order_item.html.erb
+++ b/app/views/order_items/_order_item.html.erb
@@ -1,6 +1,6 @@
 <li>
   <p>Item: <%= link_to order_item.item.title, item_path(order_item.item) %></p>
   <p>Quantity: <%= order_item.quantity %></p>
-  <p>Unit Cost: <%= in_dollars(order_item.unit_cost) %></p>
+  <p>Unit Cost: <%= in_dollars(order_item.original_unit_price) %></p>
   <p>Subtotal: <%= in_dollars(order_item.subtotal) %></p>
 </li>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -2,6 +2,16 @@
 <br />
     <%= form_for @user do |f| %>
     <div class="form-group">
+      <%= f.label :name %><br />
+      <span class="glyphicon glyphicon-user" aria-hidden="true"></span>
+      <%= f.text_field :name, placeholder: "full name" %>
+    </div>
+    <div class="form-group">
+      <%= f.label :address %><br />
+      <span class="glyphicon glyphicon-user" aria-hidden="true"></span>
+      <%= f.text_field :address, placeholder: "address" %>
+    </div>
+    <div class="form-group">
       <%= f.label :username %><br />
       <span class="glyphicon glyphicon-user" aria-hidden="true"></span>
       <%= f.text_field :username, placeholder: "username" %>

--- a/db/migrate/20171030231517_create_items.rb
+++ b/db/migrate/20171030231517_create_items.rb
@@ -3,7 +3,7 @@ class CreateItems < ActiveRecord::Migration[5.1]
     create_table :items do |t|
       t.string :title, null: false
       t.string :image_url, null: false
-      t.integer :unit_price, null: false
+      t.integer :price, null: false
       t.text :description, null: false
     end
   end

--- a/db/migrate/20171030231517_create_items.rb
+++ b/db/migrate/20171030231517_create_items.rb
@@ -3,7 +3,7 @@ class CreateItems < ActiveRecord::Migration[5.1]
     create_table :items do |t|
       t.string :title, null: false
       t.string :image_url, null: false
-      t.integer :price, null: false
+      t.integer :unit_price, null: false
       t.text :description, null: false
     end
   end

--- a/db/migrate/20171101221242_create_orders.rb
+++ b/db/migrate/20171101221242_create_orders.rb
@@ -1,7 +1,7 @@
 class CreateOrders < ActiveRecord::Migration[5.1]
   def change
     create_table :orders do |t|
-      t.string :service_address
+      t.string :original_address
       t.string :purchaser_name, null: false
       t.integer :status, null: false, default: 0
       t.timestamps null: false

--- a/db/migrate/20171101221242_create_orders.rb
+++ b/db/migrate/20171101221242_create_orders.rb
@@ -2,7 +2,7 @@ class CreateOrders < ActiveRecord::Migration[5.1]
   def change
     create_table :orders do |t|
       t.string :original_address
-      t.string :purchaser_name, null: false
+      t.string :original_purchaser, null: false
       t.integer :status, null: false, default: 0
       t.timestamps null: false
 

--- a/db/migrate/20171101221242_create_orders.rb
+++ b/db/migrate/20171101221242_create_orders.rb
@@ -1,8 +1,8 @@
 class CreateOrders < ActiveRecord::Migration[5.1]
   def change
     create_table :orders do |t|
-      t.string :original_address
-      t.string :original_purchaser, null: false
+      t.string :service_address
+      t.string :purchaser_name, null: false
       t.integer :status, null: false, default: 0
       t.timestamps null: false
 

--- a/db/migrate/20171102011521_create_order_items.rb
+++ b/db/migrate/20171102011521_create_order_items.rb
@@ -5,7 +5,7 @@ class CreateOrderItems < ActiveRecord::Migration[5.1]
       t.references :order, index: true, foreign_key: true
       t.references :item, index: true, foreign_key: true
 
-      t.integer :unit_cost, null: false
+      t.integer :original_unit_price, null: false
       t.integer :quantity, null: false
 
     end

--- a/db/migrate/20171102011521_create_order_items.rb
+++ b/db/migrate/20171102011521_create_order_items.rb
@@ -5,7 +5,7 @@ class CreateOrderItems < ActiveRecord::Migration[5.1]
       t.references :order, index: true, foreign_key: true
       t.references :item, index: true, foreign_key: true
 
-      t.integer :original_unit_price, null: false
+      t.integer :unit_cost, null: false
       t.integer :quantity, null: false
 
     end

--- a/db/migrate/20171107211328_change_price_to_unit_price_in_items.rb
+++ b/db/migrate/20171107211328_change_price_to_unit_price_in_items.rb
@@ -1,0 +1,5 @@
+class Changeunit_priceToUnitunit_priceInItems < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :items, :unit_price, :unit_unit_price
+  end
+end

--- a/db/migrate/20171107211328_change_price_to_unit_price_in_items.rb
+++ b/db/migrate/20171107211328_change_price_to_unit_price_in_items.rb
@@ -1,5 +1,5 @@
-class Changeunit_priceToUnitunit_priceInItems < ActiveRecord::Migration[5.1]
+class ChangeUnitCostToUnitPriceInItems < ActiveRecord::Migration[5.1]
   def change
-    rename_column :items, :unit_price, :unit_unit_price
+    rename_column :items, :unit_cost, :unit_price
   end
 end

--- a/db/migrate/20171107211328_change_price_to_unit_price_in_items.rb
+++ b/db/migrate/20171107211328_change_price_to_unit_price_in_items.rb
@@ -1,5 +1,5 @@
-class ChangeUnitCostToUnitPriceInItems < ActiveRecord::Migration[5.1]
+class ChangePriceToUnitPriceInItems < ActiveRecord::Migration[5.1]
   def change
-    rename_column :items, :unit_cost, :unit_price
+    rename_column :items, :price, :unit_price
   end
 end

--- a/db/migrate/20171107212319_add_unit_to_items.rb
+++ b/db/migrate/20171107212319_add_unit_to_items.rb
@@ -1,0 +1,5 @@
+class AddUnitToItems < ActiveRecord::Migration[5.1]
+  def change
+    add_column :items, :units, :integer
+  end
+end

--- a/db/migrate/20171107212858_add_name_to_user.rb
+++ b/db/migrate/20171107212858_add_name_to_user.rb
@@ -1,0 +1,5 @@
+class AddNameToUser < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :name, :string
+  end
+end

--- a/db/migrate/20171107213108_add_address_to_user.rb
+++ b/db/migrate/20171107213108_add_address_to_user.rb
@@ -1,0 +1,5 @@
+class AddAddressToUser < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :address, :string
+  end
+end

--- a/db/migrate/20171107213304_add_units_to_order_items.rb
+++ b/db/migrate/20171107213304_add_units_to_order_items.rb
@@ -1,0 +1,5 @@
+class AddUnitsToOrderItems < ActiveRecord::Migration[5.1]
+  def change
+    add_column :order_items, :units, :integer
+  end
+end

--- a/db/migrate/20171107213525_change_unit_cost_to_original_unit_price_in_order_items.rb
+++ b/db/migrate/20171107213525_change_unit_cost_to_original_unit_price_in_order_items.rb
@@ -1,0 +1,5 @@
+class ChangeUnitCostToOriginalUnitPriceInOrderItems < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :order_items, :original_unit_price, :original_unit_price
+  end
+end

--- a/db/migrate/20171107213525_change_unit_cost_to_original_unit_price_in_order_items.rb
+++ b/db/migrate/20171107213525_change_unit_cost_to_original_unit_price_in_order_items.rb
@@ -1,5 +1,5 @@
 class ChangeUnitCostToOriginalUnitPriceInOrderItems < ActiveRecord::Migration[5.1]
   def change
-    rename_column :order_items, :original_unit_price, :original_unit_price
+    rename_column :order_items, :unit_cost, :original_unit_price
   end
 end

--- a/db/migrate/20171107214023_change_service_address_to_original_address_in_order.rb
+++ b/db/migrate/20171107214023_change_service_address_to_original_address_in_order.rb
@@ -1,5 +1,5 @@
 class ChangeServiceAddressToOriginalAddressInOrder < ActiveRecord::Migration[5.1]
   def change
-    rename_column :orders, :original_address, :original_address
+    rename_column :orders, :service_address, :original_address
   end
 end

--- a/db/migrate/20171107214023_change_service_address_to_original_address_in_order.rb
+++ b/db/migrate/20171107214023_change_service_address_to_original_address_in_order.rb
@@ -1,0 +1,5 @@
+class ChangeServiceAddressToOriginalAddressInOrder < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :orders, :original_address, :original_address
+  end
+end

--- a/db/migrate/20171107214411_change_purchaser_name_to_original_purchaser_in_order.rb
+++ b/db/migrate/20171107214411_change_purchaser_name_to_original_purchaser_in_order.rb
@@ -1,0 +1,5 @@
+class ChangePurchaserNameToOriginalPurchaserInOrder < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :orders, :original_purchaser, :original_purchaser
+  end
+end

--- a/db/migrate/20171107214411_change_purchaser_name_to_original_purchaser_in_order.rb
+++ b/db/migrate/20171107214411_change_purchaser_name_to_original_purchaser_in_order.rb
@@ -1,5 +1,5 @@
 class ChangePurchaserNameToOriginalPurchaserInOrder < ActiveRecord::Migration[5.1]
   def change
-    rename_column :orders, :original_purchaser, :original_purchaser
+    rename_column :orders, :purchaser_name, :original_purchaser
   end
 end

--- a/db/migrate/20171107223521_change_null_constraints.rb
+++ b/db/migrate/20171107223521_change_null_constraints.rb
@@ -1,0 +1,9 @@
+class ChangeNullConstraints < ActiveRecord::Migration[5.1]
+  def change
+    change_column_null :items, :units, false
+    change_column_null :users, :name, false
+    change_column_null :users, :address, false
+    change_column_null :order_items, :units, false
+    change_column_null :orders, :original_address, false
+  end
+end

--- a/db/migrate/20171107224216_add_default_to_units.rb
+++ b/db/migrate/20171107224216_add_default_to_units.rb
@@ -1,0 +1,6 @@
+class AddDefaultToUnits < ActiveRecord::Migration[5.1]
+  def change
+    change_column_default :items, :units, 2
+    change_column_default :order_items, :units, 2
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171107213525) do
+ActiveRecord::Schema.define(version: 20171107214023) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,7 +44,7 @@ ActiveRecord::Schema.define(version: 20171107213525) do
   end
 
   create_table "orders", force: :cascade do |t|
-    t.string "service_address"
+    t.string "original_address"
     t.string "purchaser_name", null: false
     t.integer "status", default: 0, null: false
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171107212858) do
+ActiveRecord::Schema.define(version: 20171107213108) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,6 +58,7 @@ ActiveRecord::Schema.define(version: 20171107212858) do
     t.string "email", null: false
     t.integer "role", default: 0, null: false
     t.string "name"
+    t.string "address"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["username"], name: "index_users_on_username", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171107213108) do
+ActiveRecord::Schema.define(version: 20171107213304) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,6 +38,7 @@ ActiveRecord::Schema.define(version: 20171107213108) do
     t.bigint "item_id"
     t.integer "unit_cost", null: false
     t.integer "quantity", null: false
+    t.integer "units"
     t.index ["item_id"], name: "index_order_items_on_item_id"
     t.index ["order_id"], name: "index_order_items_on_order_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171107214411) do
+ActiveRecord::Schema.define(version: 20171107223521) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,7 +28,7 @@ ActiveRecord::Schema.define(version: 20171107214411) do
     t.text "description", null: false
     t.bigint "category_id"
     t.boolean "active", default: true, null: false
-    t.integer "units"
+    t.integer "units", null: false
     t.index ["category_id"], name: "index_items_on_category_id"
     t.index ["title"], name: "index_items_on_title", unique: true
   end
@@ -38,13 +38,13 @@ ActiveRecord::Schema.define(version: 20171107214411) do
     t.bigint "item_id"
     t.integer "original_unit_price", null: false
     t.integer "quantity", null: false
-    t.integer "units"
+    t.integer "units", null: false
     t.index ["item_id"], name: "index_order_items_on_item_id"
     t.index ["order_id"], name: "index_order_items_on_order_id"
   end
 
   create_table "orders", force: :cascade do |t|
-    t.string "original_address"
+    t.string "original_address", null: false
     t.string "original_purchaser", null: false
     t.integer "status", default: 0, null: false
     t.datetime "created_at", null: false
@@ -58,8 +58,8 @@ ActiveRecord::Schema.define(version: 20171107214411) do
     t.string "password_digest", null: false
     t.string "email", null: false
     t.integer "role", default: 0, null: false
-    t.string "name"
-    t.string "address"
+    t.string "name", null: false
+    t.string "address", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["username"], name: "index_users_on_username", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171107212319) do
+ActiveRecord::Schema.define(version: 20171107212858) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -57,6 +57,7 @@ ActiveRecord::Schema.define(version: 20171107212319) do
     t.string "password_digest", null: false
     t.string "email", null: false
     t.integer "role", default: 0, null: false
+    t.string "name"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["username"], name: "index_users_on_username", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171106023622) do
+ActiveRecord::Schema.define(version: 20171107211328) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,7 +24,7 @@ ActiveRecord::Schema.define(version: 20171106023622) do
   create_table "items", force: :cascade do |t|
     t.string "title", null: false
     t.string "image_url"
-    t.integer "price", null: false
+    t.integer "unit_unit_price", null: false
     t.text "description", null: false
     t.bigint "category_id"
     t.boolean "active", default: true, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171107211328) do
+ActiveRecord::Schema.define(version: 20171107212319) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,10 +24,11 @@ ActiveRecord::Schema.define(version: 20171107211328) do
   create_table "items", force: :cascade do |t|
     t.string "title", null: false
     t.string "image_url"
-    t.integer "unit_unit_price", null: false
+    t.integer "unit_price", null: false
     t.text "description", null: false
     t.bigint "category_id"
     t.boolean "active", default: true, null: false
+    t.integer "units"
     t.index ["category_id"], name: "index_items_on_category_id"
     t.index ["title"], name: "index_items_on_title", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171107213304) do
+ActiveRecord::Schema.define(version: 20171107213525) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,7 +36,7 @@ ActiveRecord::Schema.define(version: 20171107213304) do
   create_table "order_items", force: :cascade do |t|
     t.bigint "order_id"
     t.bigint "item_id"
-    t.integer "unit_cost", null: false
+    t.integer "original_unit_price", null: false
     t.integer "quantity", null: false
     t.integer "units"
     t.index ["item_id"], name: "index_order_items_on_item_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171107214023) do
+ActiveRecord::Schema.define(version: 20171107214411) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,7 +45,7 @@ ActiveRecord::Schema.define(version: 20171107214023) do
 
   create_table "orders", force: :cascade do |t|
     t.string "original_address"
-    t.string "purchaser_name", null: false
+    t.string "original_purchaser", null: false
     t.integer "status", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171107223521) do
+ActiveRecord::Schema.define(version: 20171107224216) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,7 +28,7 @@ ActiveRecord::Schema.define(version: 20171107223521) do
     t.text "description", null: false
     t.bigint "category_id"
     t.boolean "active", default: true, null: false
-    t.integer "units", null: false
+    t.integer "units", default: 2, null: false
     t.index ["category_id"], name: "index_items_on_category_id"
     t.index ["title"], name: "index_items_on_title", unique: true
   end
@@ -38,7 +38,7 @@ ActiveRecord::Schema.define(version: 20171107223521) do
     t.bigint "item_id"
     t.integer "original_unit_price", null: false
     t.integer "quantity", null: false
-    t.integer "units", null: false
+    t.integer "units", default: 2, null: false
     t.index ["item_id"], name: "index_order_items_on_item_id"
     t.index ["order_id"], name: "index_order_items_on_order_id"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -25,13 +25,13 @@ Item.create!([{
   title: "Build a Website",
   description: "I'll make you a cool website!",
   category: Category.first,
-  price: 1099,
+  unit_price: 1099,
   image_url: "http://www.makeawebsiteguru.com/wp-content/uploads/2015/04/ways-to-build-a-website.png"
 },{
   title: "Plumbing",
   description: "I'll unclog your sink!",
   category: Category.last,
-  price: 15000,
+  unit_price: 15000,
   image_url: "https://www.homedepot.com/hdus/en_US/DTCCOMNEW/fetch/Category_Pages/Kitchen/Sinks/bar-prep-sink-400x400-2.png",
   active: false
 }])

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :item do
     sequence(:title)  {|n| "Product #{n}"}
     sequence(:description)  {|n| "Description #{n}"}
-    sequence(:price)  {|n| n}
+    sequence(:unit_price)  {|n| n}
     image_url "http://placebear.com/50/100"
     category
   end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :order do
 
     user
-    sequence(:service_address) { |n| "#{n} Fake St." }
+    sequence(:original_address) { |n| "#{n} Fake St." }
 
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory :user do
+    sequence(:name)   {|n| "name_#{n}"}
+    sequence(:address)   {|n| "address_#{n}"}
     sequence(:username)   {|n| "username_#{n}"}
     sequence(:password)   {|n| "password_#{n}"}
     sequence(:email)      {|n| "email_#{n}"}

--- a/spec/features/admin/items/admin_can_create_an_item_spec.rb
+++ b/spec/features/admin/items/admin_can_create_an_item_spec.rb
@@ -11,7 +11,7 @@ feature 'When an admin creates an item' do
     visit new_admin_item_path
     fill_in 'item[title]', with: 'something unique'
     fill_in 'item[description]', with: 'something descriptive'
-    fill_in 'item[price]', with: '9.99'
+    fill_in 'item[unit_price]', with: '9.99'
     select 'Things', from: 'item[category_id]'
   end
 

--- a/spec/features/admin/items/admin_edits_an_item_spec.rb
+++ b/spec/features/admin/items/admin_edits_an_item_spec.rb
@@ -20,7 +20,7 @@ feature 'When an admin clicks edit for an item' do
     background do
       fill_in 'item[title]', with: 'something unique'
       fill_in 'item[description]', with: 'something descriptive'
-      fill_in 'item[price]', with: '79.99'
+      fill_in 'item[unit_price]', with: '79.99'
       click_on 'Update Item'
     end
 

--- a/spec/features/admin/orders/admin_can_view_an_order_spec.rb
+++ b/spec/features/admin/orders/admin_can_view_an_order_spec.rb
@@ -27,7 +27,7 @@ feature 'When an admin visits an order page' do
   end
 
   scenario 'they can see the purchaser\'s full name and address' do
-    expect(page).to have_content(Order.first.purchaser_name)
+    expect(page).to have_content(Order.first.original_purchaser)
     expect(page).to have_content(Order.first.original_address)
   end
 

--- a/spec/features/admin/orders/admin_can_view_an_order_spec.rb
+++ b/spec/features/admin/orders/admin_can_view_an_order_spec.rb
@@ -28,7 +28,7 @@ feature 'When an admin visits an order page' do
 
   scenario 'they can see the purchaser\'s full name and address' do
     expect(page).to have_content(Order.first.purchaser_name)
-    expect(page).to have_content(Order.first.service_address)
+    expect(page).to have_content(Order.first.original_address)
   end
 
   feature 'and looks at each item' do

--- a/spec/features/admin/orders/admin_can_view_an_order_spec.rb
+++ b/spec/features/admin/orders/admin_can_view_an_order_spec.rb
@@ -8,7 +8,7 @@ feature 'When an admin visits an order page' do
       .and_return(create(:admin))
 
     order = create(:order)
-    items = create_list(:item, 2, price: 7)
+    items = create_list(:item, 2, unit_price: 7)
     create(:order_item, order: order, quantity: 1, item: items.first)
     create(:order_item, order: order, quantity: 2, item: items.last)
     visit admin_order_path(order)
@@ -38,7 +38,7 @@ feature 'When an admin visits an order page' do
       expect(page).to have_link(Item.last.title, href: item_path(Item.last))
     end
 
-    scenario 'they see the unit price' do
+    scenario 'they see the unit unit_price' do
       expect(page).to have_content(OrderItem.first.unit_cost)
       expect(page).to have_content(OrderItem.last.unit_cost)
     end

--- a/spec/features/admin/orders/admin_can_view_an_order_spec.rb
+++ b/spec/features/admin/orders/admin_can_view_an_order_spec.rb
@@ -39,8 +39,8 @@ feature 'When an admin visits an order page' do
     end
 
     scenario 'they see the unit unit_price' do
-      expect(page).to have_content(OrderItem.first.unit_cost)
-      expect(page).to have_content(OrderItem.last.unit_cost)
+      expect(page).to have_content(OrderItem.first.original_unit_price)
+      expect(page).to have_content(OrderItem.last.original_unit_price)
     end
 
     scenario 'they see the quantity' do

--- a/spec/features/cart/user_checks_out_spec.rb
+++ b/spec/features/cart/user_checks_out_spec.rb
@@ -24,7 +24,7 @@ feature 'the cart page' do
 
     scenario 'the user sees the placed order in a table' do
       expect(page).to have_content(Item.first.title)
-      expect(page).to have_content(Item.first.price)
+      expect(page).to have_content(Item.first.unit_price)
       expect(page).to have_content("Quantity: #{OrderItem.first.quantity}")
       expect(page).to have_content('Subtotal: $%.2f' % (OrderItem.first.subtotal / 100.0))
     end

--- a/spec/features/cart/visitor_can_add_items_to_cart_spec.rb
+++ b/spec/features/cart/visitor_can_add_items_to_cart_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe "when a visitor adds an item to cart and visits cart" do
   before do
-    item = create(:item, price: 2)
+    item = create(:item, unit_price: 2)
     visit items_path
     click_on("Add to Cart")
     find("#go-to-cart").click
@@ -15,13 +15,13 @@ describe "when a visitor adds an item to cart and visits cart" do
   it "they can see details about the item they added" do
     expect(page).to have_content(Item.first.title)
     expect(page).to have_content(Item.first.description)
-    expect(page).to have_content(Item.first.price)
+    expect(page).to have_content(Item.first.unit_price)
     expect(first("img")['alt']).to have_content(Item.first.title)
   end
 
   context "when a visitor has more than one item in the cart" do
-    it "there is a total price for all items in the cart" do
-      create_list(:item, 3, price: 2)
+    it "there is a total unit_price for all items in the cart" do
+      create_list(:item, 3, unit_price: 2)
       visit items_path
       all('.add-to-cart').each &:click
       find("#go-to-cart").click

--- a/spec/features/cart/visitor_can_decrease_quantity_of_item_in_cart_spec.rb
+++ b/spec/features/cart/visitor_can_decrease_quantity_of_item_in_cart_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe "when a visitor has an item in the cart" do
   before do
-    create(:item, price: 200)
+    create(:item, unit_price: 200)
     visit items_path
     first("input.add-to-cart").click
     first("input.add-to-cart").click
@@ -33,7 +33,7 @@ describe "when a visitor has an item in the cart" do
   it "they can see an updated total for the whole cart" do
     fill_in "quantity", with: 1
     click_on "Update Quantity"
-    item = create(:item, price: 500)
+    item = create(:item, unit_price: 500)
     visit items_path
     page.all("input.add-to-cart")[1].click
     find("#go-to-cart").click

--- a/spec/features/cart/visitor_can_increase_quantity_of_items_in_cart_spec.rb
+++ b/spec/features/cart/visitor_can_increase_quantity_of_items_in_cart_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe "when a visitor has an item in the cart" do
   before do
-    item = create(:item, price: 200)
+    item = create(:item, unit_price: 200)
     visit items_path
     click_on("Add to Cart")
     find("#go-to-cart").click
@@ -32,7 +32,7 @@ describe "when a visitor has an item in the cart" do
   it "they can see an updated total for the whole cart" do
     fill_in "quantity", with: 3
     click_on "Update Quantity"
-    item = create(:item, price: 500)
+    item = create(:item, unit_price: 500)
     visit items_path
     page.all("input.add-to-cart")[1].click
     find("#go-to-cart").click

--- a/spec/features/cart/visitor_checks_out_spec.rb
+++ b/spec/features/cart/visitor_checks_out_spec.rb
@@ -11,7 +11,7 @@ describe "a visitor visits their cart" do
     it "they do not see an option to checkout" do
       expect(current_path).to eq(cart_path)
       expect(page).to have_content(Item.first.title)
-      expect(page).to have_content(Item.first.price)
+      expect(page).to have_content(Item.first.unit_price)
       expect(page).to have_content(Item.first.description)
       expect(first("img")['alt']).to have_content(Item.first.title)
       expect(page).to have_content("Login or Create Account to Checkout")
@@ -35,7 +35,7 @@ describe "a visitor visits their cart" do
       visit cart_path
 
       expect(page).to have_content(Item.first.title)
-      expect(page).to have_content(Item.first.price)
+      expect(page).to have_content(Item.first.unit_price)
       expect(page).to have_content(Item.first.description)
       expect(first("img")['alt']).to have_content(Item.first.title)
     end

--- a/spec/features/items/visitor_can_see_a_single_item_spec.rb
+++ b/spec/features/items/visitor_can_see_a_single_item_spec.rb
@@ -18,8 +18,8 @@ feature "when a visitor goes to the item show page"do
     expect(page).to have_content(item.title)
   end
 
-  scenario "they see the price of the item" do
-    expect(page).to have_content('$%.2f' % (item.price / 100.0))
+  scenario "they see the unit_price of the item" do
+    expect(page).to have_content('$%.2f' % (item.unit_price / 100.0))
   end
 
   scenario "they see the item's description" do

--- a/spec/features/orders/user_views_one_past_order_spec.rb
+++ b/spec/features/orders/user_views_one_past_order_spec.rb
@@ -59,7 +59,7 @@ feature 'The past order show page' do
         )
       end
 
-      scenario 'displays the total price of the order' do
+      scenario 'displays the total unit_price of the order' do
         expect(page).to have_content('Total Cost: $%.2f' % (@order.total_cost / 100.0))
       end
 

--- a/spec/features/orders/user_views_their_past_orders_spec.rb
+++ b/spec/features/orders/user_views_their_past_orders_spec.rb
@@ -44,7 +44,7 @@ feature 'The past orders page' do
                     .and have_link(href: item_path(@item2))
       end
 
-      scenario('displays the total price of the order') do
+      scenario('displays the total unit_price of the order') do
         expect(page).to have_content('Total Cost: $%.2f' % (@order.total_cost / 100.0))
       end
 

--- a/spec/features/users/visitor_can_create_an_account_spec.rb
+++ b/spec/features/users/visitor_can_create_an_account_spec.rb
@@ -5,6 +5,8 @@ feature 'When a visitor submits the form to create a new account' do
   background do
     visit login_path
     click_on "Create Account"
+    fill_in 'user[name]', with: 'Jane Doe'
+    fill_in 'user[address]', with: 'Fake St'
     fill_in 'user[username]', with: 'JaneDoe89'
     fill_in 'user[email]', with: 'janedoe89@example.com'
     fill_in 'user[password]', with: 'pw'

--- a/spec/models/cart_spec.rb
+++ b/spec/models/cart_spec.rb
@@ -59,9 +59,9 @@ describe Cart do
     end
   end
 
-  describe '#total_unit_price' do
-    it 'can find the total unit_price of all contents as an integer' do
-      expect(@cart.total_unit_price).to be(90)
+  describe '#total' do
+    it 'can find the total price of all contents as an integer' do
+      expect(@cart.total).to be(90)
     end
   end
 end

--- a/spec/models/cart_spec.rb
+++ b/spec/models/cart_spec.rb
@@ -3,9 +3,9 @@ require 'rails_helper'
 describe Cart do
 
   before do
-    item1 = create(:item, id: 1, price: 10)
-    item2 = create(:item, id: 2, price: 10)
-    item3 = create(:item, id: 3, price: 10)
+    item1 = create(:item, id: 1, unit_price: 10)
+    item2 = create(:item, id: 2, unit_price: 10)
+    item3 = create(:item, id: 3, unit_price: 10)
     @cart = Cart.new("1" => 2, "2" => 3, "3" => 4)
   end
 
@@ -59,9 +59,9 @@ describe Cart do
     end
   end
 
-  describe '#total_price' do
-    it 'can find the total price of all contents as an integer' do
-      expect(@cart.total_price).to be(90)
+  describe '#total_unit_price' do
+    it 'can find the total unit_price of all contents as an integer' do
+      expect(@cart.total_unit_price).to be(90)
     end
   end
 end

--- a/spec/models/cart_spec.rb
+++ b/spec/models/cart_spec.rb
@@ -61,7 +61,7 @@ describe Cart do
 
   describe '#total' do
     it 'can find the total price of all contents as an integer' do
-      expect(@cart.total).to be(90)
+      expect(@cart.total_price).to be(90)
     end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -4,11 +4,11 @@ describe Item do
 
   describe 'validations' do
 
-    it 'succeed with a unique title, description, price, and category' do
+    it 'succeed with a unique title, description, unit_price, and category' do
       item = Item.new(
         title: 'item title',
         description: 'item description',
-        price: 9.99,
+        unit_price: 9.99,
         category: create(:category)
       )
       expect(item).to be_valid
@@ -18,7 +18,7 @@ describe Item do
       item = Item.new(
         title: 'item title',
         description: 'item description',
-        price: 9.99,
+        unit_price: 9.99,
         image_url: 'example.com/item.jpg',
         category: create(:category)
       )
@@ -30,7 +30,7 @@ describe Item do
       item = Item.new(
         title: 'item title',
         description: 'item description',
-        price: 9.99,
+        unit_price: 9.99,
         category: create(:category)
       )
       expect(item).to_not be_valid
@@ -39,7 +39,7 @@ describe Item do
     it 'fail without a title' do
       item = Item.new(
         description: 'item description',
-        price: 9.99,
+        unit_price: 9.99,
         category: create(:category)
       )
       expect(item).to_not be_valid
@@ -48,13 +48,13 @@ describe Item do
     it 'fail without a description' do
       item = Item.new(
         title: 'item name',
-        price: 9.99,
+        unit_price: 9.99,
         category: create(:category)
       )
       expect(item).to_not be_valid
     end
 
-    it 'fail without a price' do
+    it 'fail without a unit_price' do
       item = Item.new(
         title: 'item name',
         description: 'item description',
@@ -67,7 +67,7 @@ describe Item do
       item = Item.new(
         title: 'item name',
         description: 'item description',
-        price: 9.99,
+        unit_price: 9.99,
       )
       expect(item).to_not be_valid
     end

--- a/spec/models/order_item_spec.rb
+++ b/spec/models/order_item_spec.rb
@@ -40,9 +40,9 @@ describe OrderItem do
   end
 
   describe 'defaults' do
-    it 'unit_cost to the item\'s price' do
+    it 'unit_cost to the item\'s unit_price' do
       order_item = create(:order_item)
-      expect(order_item.unit_cost).to eq(order_item.item.price)
+      expect(order_item.unit_cost).to eq(order_item.item.unit_price)
     end
   end
 

--- a/spec/models/order_item_spec.rb
+++ b/spec/models/order_item_spec.rb
@@ -40,9 +40,9 @@ describe OrderItem do
   end
 
   describe 'defaults' do
-    it 'unit_cost to the item\'s unit_price' do
+    it 'original_unit_price to the item\'s unit_price' do
       order_item = create(:order_item)
-      expect(order_item.unit_cost).to eq(order_item.item.unit_price)
+      expect(order_item.original_unit_price).to eq(order_item.item.unit_price)
     end
   end
 
@@ -61,8 +61,8 @@ describe OrderItem do
   end
 
   describe 'instance methods' do
-    it '#subtotal returns the unit_cost * quantity in cents' do
-      order_item = create(:order_item, unit_cost: 199, quantity: 2)
+    it '#subtotal returns the original_unit_price * quantity in cents' do
+      order_item = create(:order_item, original_unit_price: 199, quantity: 2)
       expect(order_item.subtotal).to eq(398)
     end
   end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -50,7 +50,7 @@ describe Order do
 
   describe 'instance methods' do
     it '#total_cost returns the total cost in cents' do
-      order = create(:order_item, unit_cost: 199, quantity: 2).order
+      order = create(:order_item, original_unit_price: 199, quantity: 2).order
       expect(order.total_cost).to eq(398)
     end
   end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -29,7 +29,7 @@ describe Order do
       expect(@order.ordered?).to be true
     end
     it 'purchaser name to the user\'s username' do
-      expect(@order.purchaser_name).to eq(@order.user.username)
+      expect(@order.original_purchaser).to eq(@order.user.username)
     end
   end
 

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -14,7 +14,7 @@ describe Order do
     end
 
     it 'pass with optional service address' do
-      order = Order.new(user: create(:user), service_address: '1234 Fake St.')
+      order = Order.new(user: create(:user), original_address: '1234 Fake St.')
       expect(order).to be_valid
     end
 

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -28,7 +28,7 @@ describe Order do
     it 'status to "ordered"' do
       expect(@order.ordered?).to be true
     end
-    it 'purchaser name to the user\'s username' do
+    xit 'purchaser name to the user\'s username' do
       expect(@order.original_purchaser).to eq(@order.user.username)
     end
   end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -23,7 +23,7 @@ describe Order do
 
   describe 'defaults' do
     before do
-      @order = Order.create(user: create(:user))
+      @order = Order.create(original_purchaser: create(:user), original_address: "address")
     end
     it 'status to "ordered"' do
       expect(@order.ordered?).to be true


### PR DESCRIPTION
Closes #214 #161 #155 

Description of Changes:
Table Updates:
-items: units, price -> unit_price
-users: name, address
-order_items: units, unit_cost -> original_unit_price
-orders: service_address -> original_address, purchaser_name -> original_purchaser

To Do: 
-add enum for units ([15 minutes, hourly, daily, flat_rate], need for both item and order_items)
-make original_address and _purchaser have user information as default values

@anlewi5, @josimccllelan, @aziobrow


