### PR TITLE
Admin edit info

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -7,4 +7,20 @@ class Admin::UsersController < ApplicationController
     @orders = Order.parse_params(params)
   end
 
+  def edit
+    @user = User.find(current_user.id)
+  end
+
+  def update
+    @user = User.update(current_user.id, admin_user_params)
+    flash[:success] = "Profile Successfully Updated"
+    redirect_to admin_dashboard_path
+  end
+
+  private
+
+  def admin_user_params
+    params.require(:user).permit(:username, :email, :name, :address)
+  end
+
 end

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,0 +1,17 @@
+<h1>Edit <%= @user.name %>:</h1>
+
+<%= form_for [:admin, @user] do |f| %>
+  <%= f.label :username %>
+  <%= f.text_field :username %>
+
+  <%= f.label :email %>
+  <%= f.text_field :email %>
+
+  <%= f.label :name %>
+  <%= f.text_field :name %>
+
+  <%= f.label :address %>
+  <%= f.text_field :address %>
+
+  <%= f.submit "Update Profile" %>
+<% end %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,5 +1,7 @@
 <h1>Admin Dashboard</h1>
 
+<%= link_to "Update Profile Information", admin_edit_path %>
+
 <h3> Order Breakdown </h3>
 <h5> <%= "Ordered (#{@all_orders.ordered.count})" %></h5>
 <h5> <%= "Paid (#{@all_orders.paid.count})" %> </h5>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,8 @@ Rails.application.routes.draw do
     resources :orders, only: [:show]
     resources :items, only: [:new, :create, :edit, :update, :index]
     get '/dashboard', to: 'users#show'
+    get '/edit', to: 'users#edit'
+    resources :users, only: [:update]
   end
 
   get '/:slug', to: 'categories#show', as: 'category_items'

--- a/spec/features/admin/default_user_cannot_find_admin_pages_spec.rb
+++ b/spec/features/admin/default_user_cannot_find_admin_pages_spec.rb
@@ -15,4 +15,18 @@ feature 'When an default user visits an admin page' do
     end
   end
 
+  describe 'for an admin dashboard' do
+    scenario 'they get the 404 page' do
+      expect{ visit admin_order_path(create(:order)) }
+      .to raise_error(ActionController::RoutingError)
+    end
+  end
+
+  describe 'for an admin edit page' do
+    scenario 'they get the 404 page' do
+      expect{ visit admin_order_path(create(:order)) }
+      .to raise_error(ActionController::RoutingError)
+    end
+  end
+
 end

--- a/spec/features/admin/users/admin_can_edit_own_info_spec.rb
+++ b/spec/features/admin/users/admin_can_edit_own_info_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe "an admin can edit personal info" do
+  before do
+    admin = create(:user, role: 'admin')
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+    visit admin_dashboard_path
+  end
+
+  it "they see a link to update profile" do
+    expect(page).to have_link("Update Profile Information")
+  end
+
+  it "they can see an edit form to update information" do
+    click_on("Update Profile Information")
+
+    expect(current_path).to eq(admin_edit_path)
+    expect(page).to have_content("Username")
+    expect(page).to have_content("Email")
+    expect(page).to have_content("Name")
+    expect(page).to have_content("Address")
+    fill_in "user[username]", with: "newname1"
+    click_button "Update Profile"
+
+    expect(current_path).to eq(admin_dashboard_path)
+  end
+end


### PR DESCRIPTION
Closes #16, Closes #211, 

Description of Changes:
Added routes to edit/update admin
Doesn't take id, so no way for admin to edit other users
Added tests that default user can't access edit path
Updated Admin/Users controller for edit and update
Updated view with form






@anlewi5, @josimccllelan, @aziobrow


